### PR TITLE
Fix #6: Unable to export

### DIFF
--- a/HaydeeExporter.py
+++ b/HaydeeExporter.py
@@ -375,7 +375,7 @@ def write_dmesh(operator, context, filepath, export_skeleton,
                     continue
 
                 if len(materials) > 1:
-                    group_name = ob.name + '_' + mat.name
+                    group_name = ob.name + '_' + materials[current_material_index].name
                 else:
                     group_name = ob.name
                 regex = re.compile('^[0-9]')


### PR DESCRIPTION
Previously the group name was partially set to `mat.name`  but Matrices lack the `.name` propertiy.
This fix replaces the matrix reference with the material which is to be exported.